### PR TITLE
Fully expand in/out filename arguments

### DIFF
--- a/parse.bat
+++ b/parse.bat
@@ -1,6 +1,6 @@
 @echo off
-set INPUT=%1
-set OUTPUT=%2
+set INPUT=%~f1
+set OUTPUT=%~f2
 
 echo USAGE: parse [inputfile [outputfile]]
 


### PR DESCRIPTION
#8 "On Command Prompt, parse.bat doesn't work with filenames containing spaces."

After this fix, wrapping file args in double quotes works for filenames with spaces